### PR TITLE
refactor and fix code style

### DIFF
--- a/Controller/MailChimpController.php
+++ b/Controller/MailChimpController.php
@@ -58,8 +58,8 @@ class MailChimpController extends Controller
 
         if($status){
             try {
-                $repository = $this->getDoctrine()->getManager();
-                $repository->getConnection()->beginTransaction();
+                $em = $this->getDoctrine()->getManager();
+                $em->getConnection()->beginTransaction();
 
                 $wizard = $this->get('campaignchain.core.channel.wizard');
                 $wizard->setName($profile->displayName);
@@ -96,17 +96,17 @@ class MailChimpController extends Controller
                 $user->setPhone($profile->phone);
                 $user->setWebsiteUrl($profile->webSiteURL);
 
-                $repository->persist($user);
-                $repository->flush();
+                $em->persist($user);
+                $em->flush();
 
-                $repository->getConnection()->commit();
+                $em->getConnection()->commit();
 
                 $this->get('session')->getFlashBag()->add(
                     'success',
                     'The MailChimp location <a href="#">'.$profile->displayName.'</a> was connected successfully.'
                 );
             } catch (\Exception $e) {
-                $repository->getConnection()->rollback();
+                $em->getConnection()->rollback();
                 throw $e;
             }
         } else {


### PR DESCRIPTION
- fix code style
- extract queries to CampaignChainCoreBundle:Campaign repository
- remove unused namespace imports
- extract form generation to getCampaignType() to reduce boiler plate
- use $this->addFlash() instead of $this->get('session')->getFlashBag()->add()
- use $this->redirectToRoute() instead of $this->redirect($this->generateUrl())
- rename $repository to $em, because it contains the Entity Manager and not a repository
- replace serializer generation with a serializer service to reduce boiler plate
- inject serializer service where necessary
- remove unnecessary $response variable
- remove unnecessary $response->setStatusCode(Response::HTTP_OK) - it's already the default
